### PR TITLE
Update: Rename class MotionCollideBehavior to HoverCollideBehavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install git+https://github.com/pythonic64/hover.git
 from kivy_garden.hover import (
     HoverManager,
     HoverBehavior,
-    MotionCollideBehavior
+    HoverCollideBehavior
 )
 ```
 
@@ -26,9 +26,9 @@ from kivy_garden.hover import (
   - `on_hover_enter`, `on_hover_update`, `on_hover_leave` events which will
     dispatch when a hover indicator has entered, hovered over, or left
     a widget.
-- `MotionCollideBehavior` - a mixin class to be used with a `StencilView` or
-  its subclasses to pass hover events to child widgets only if a hover
-  indicator is hovering over a widget or when hover event is a grabbed event.
+- `HoverCollideBehavior` - a mixin class to be used with a `StencilView` or
+  its subclasses to filter hover events which are currently grabbed by the 
+  widget itself or events which collide with the widget.
 
 ### Examples
 See [simple_app.py](examples%2Fsimple_app.py) for a basic example on how to

--- a/examples/large_app.py
+++ b/examples/large_app.py
@@ -10,7 +10,7 @@ from kivy.properties import StringProperty, ColorProperty, AliasProperty
 from kivy.uix.behaviors import ButtonBehavior
 from kivy_garden.hover import (
     HoverBehavior,
-    MotionCollideBehavior,
+    HoverCollideBehavior,
     HoverManager
 )
 from kivy.uix.boxlayout import BoxLayout
@@ -375,11 +375,11 @@ class UserItem(HoverBehavior, RecycleDataViewBehavior, BoxLayout):
     hovered_color = ColorProperty([0.4, 0.4, 0.4, 1.0])
 
 
-class HoverRecycleView(MotionCollideBehavior, RecycleView):
+class HoverRecycleView(HoverCollideBehavior, RecycleView):
     pass
 
 
-class HoverDropDown(MotionCollideBehavior, DropDown):
+class HoverDropDown(HoverCollideBehavior, DropDown):
     pass
 
 

--- a/kivy_garden/hover/__init__.py
+++ b/kivy_garden/hover/__init__.py
@@ -254,6 +254,9 @@ class HoverManager(EventManagerBase):
             )
 
     def stop(self):
+        for me_list in self._events.values():
+            me, grab_list = me_list[0]
+            self._dispatch_to_grabbed_widgets(me, grab_list)
         self._events.clear()
         self._event_times.clear()
         if self._clock_event:

--- a/kivy_garden/hover/__init__.py
+++ b/kivy_garden/hover/__init__.py
@@ -211,15 +211,19 @@ class HoverManager(EventManagerBase):
     """Manager for dispatching hover events to widgets in the window children
     list.
 
-    When registered, manager will receive all events with `type_id` set to
+    When registered, a manager will receive all events with `type_id` set to
     "hover", transform them to match :attr:`window` size and then dispatch them
     through the `window.children` list using the `on_motion` event.
 
-    To handle a case when the hover event position did not change within
-    `event_repeat_timeout` seconds, manager will re-dispatch the event with all
-    delta values set to 0, so that widgets can re-handle the event.
+    To handle the case when the hover event position did not change within
+    :attr:`event_repeat_timeout` seconds, manager will re-dispatch the event
+    with all delta values set to 0, so that widgets can re-handle the event.
     This is useful for the case when a mouse is used to scroll a recyclable
     list of widgets, but the mouse indicator position is not changing.
+
+    When a manager is stopped and if there are widgets stored in its internal
+    storage who grabbed hover events, then a manager will dispatch event type
+    "end" to all those widgets, so that they can update their internal state.
     """
 
     type_ids = ('hover',)

--- a/kivy_garden/hover/__init__.py
+++ b/kivy_garden/hover/__init__.py
@@ -8,10 +8,9 @@ This module defines three classes to handle hover events:
    in the `Window`'s :attr:`~kivy.core.window.WindowBase.children` list.
 2. Class :class:`HoverBehavior` handles hover events for all widgets who
    inherit from it.
-3. Class :class:`MotionCollideBehavior` provides filtering of all events
-   (not just hover events) in such way that only grabbed events or events who
-   have "pos" in :attr:`~kivy.input.motionevent.MotionEvent.profile` and can
-   pass a collision check are passed through the
+3. Class :class:`HoverCollideBehavior` provides filtering of hover events in
+   such way that only events for which currently grabbed widget is the widget
+   itself or events which collide with the widget are passed through the
    :meth:`~kivy.uix.widget.Widget.on_motion` method.
 
 A hover event is an instance of :class:`~kivy.input.motionevent.MotionEvent`
@@ -165,8 +164,8 @@ HoverCollideBehavior
 
 :class:`HoverCollideBehavior` is a
 `mixin <https://en.wikipedia.org/wiki/Mixin>`_ class which filters hover events
-which do not collide with a widget or events for which currently grabbed
-widget is not the widget itself.
+which are currently grabbed by the widget itself or events which collide with
+the widget.
 
 For an overview of behaviors, please refer to the :mod:`~kivy.uix.behaviors`
 documentation.
@@ -174,7 +173,8 @@ documentation.
 :class:`HoverCollideBehavior` is meant to be used with
 :class:`~kivy.uix.stencilview.StencilView` or its subclasses so that hover
 events (events with :attr:`~kivy.input.motionevent.MotionEvent.type_id` set to
-"hover") don't get handled when their position is outside the view.
+"hover") don't get handled when their position is outside the view's bounding
+box.
 
 Example of using :class:`HoverCollideBehavior` with
 :class:`~kivy.uix.recycleview.RecycleView`::


### PR DESCRIPTION
### Changes:
- Renamed class MotionCollideBehavior to HoverCollideBehavior and re-work it to only handle hover events.
- Updated `HoverManager` to dispatch "end" etype to grabbed widgets in method `stop`.
- Updated documentation.
- Updated "README.md".